### PR TITLE
feat: add emulator toolbox sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The default emulator profile uses a slow fake-success Codex flow and seeds demo 
 node scripts/launch-me-emulator.js --profile ready --seed demo --keep-sandbox
 ```
 
+In emulator mode, the app shows a right-side toolbox with quick status shortcuts and reset actions so you can seed or mutate test tasks from the UI.
+
 Available emulator profiles:
 
 - `missing`: no Codex available

--- a/electron/codex-env.js
+++ b/electron/codex-env.js
@@ -52,6 +52,14 @@ function defaultAppConfig() {
   };
 }
 
+function buildEmulatorInfo({ env = process.env } = {}) {
+  return {
+    enabled: env.ME_EMULATOR === "1",
+    profile: env.ME_EMULATOR_PROFILE || null,
+    seed: env.ME_EMULATOR_SEED || null,
+  };
+}
+
 function defaultPersonalAgentsTemplate() {
   return `# Personal Me Instructions
 
@@ -261,11 +269,13 @@ async function buildCodexInfo({
       env,
       osModule,
     }),
+    emulator: buildEmulatorInfo({ env }),
   };
 }
 
 module.exports = {
   appConfigPath,
+  buildEmulatorInfo,
   buildCodexBinaryCandidates,
   buildCodexInfo,
   defaultAppConfig,

--- a/electron/main.js
+++ b/electron/main.js
@@ -6,6 +6,7 @@ const os = require("node:os");
 const path = require("node:path");
 const readline = require("node:readline");
 const codexEnv = require("./codex-env");
+const emulatorLib = require("../scripts/me-emulator-lib");
 
 let mainWindow = null;
 let backendProcess = null;
@@ -462,6 +463,49 @@ async function connectCodexBinary() {
   return buildCodexInfo();
 }
 
+function isEmulatorMode() {
+  return process.env.ME_EMULATOR === "1";
+}
+
+async function replaceAllTasks(tasks) {
+  const nextTasks = await sendBackendRequest("replace_all", { tasks });
+  broadcastTasks(nextTasks);
+  return nextTasks;
+}
+
+async function runEmulatorAction({ action, title }) {
+  if (!isEmulatorMode()) {
+    throw new Error("Emulator toolbox is only available in emulator mode.");
+  }
+
+  if (action === "seed-demo") {
+    return replaceAllTasks(emulatorLib.buildSeedTasks("demo"));
+  }
+
+  if (action === "clear-all") {
+    return replaceAllTasks([]);
+  }
+
+  if (!action.startsWith("add-")) {
+    throw new Error(`Unknown emulator action: ${action}`);
+  }
+
+  const shortcut = action.slice(4);
+
+  if (!emulatorLib.TOOLBOX_SHORTCUTS.includes(shortcut)) {
+    throw new Error(`Unknown emulator shortcut: ${shortcut}`);
+  }
+
+  const currentTasks = await sendBackendRequest("list");
+  const nextTask = emulatorLib.buildShortcutTask({
+    shortcut,
+    title,
+    runnerPid: process.pid,
+  });
+
+  return replaceAllTasks([nextTask, ...currentTasks]);
+}
+
 function compactPromptText(value, maxChars = 4_000) {
   const trimmed = value.trim();
 
@@ -913,6 +957,7 @@ function registerIpcHandlers() {
     sendBackendRequest("delete", { id }),
   );
   ipcMain.handle("tasks:run-codex", (_event, payload) => startCodexTask(payload));
+  ipcMain.handle("emulator:action", (_event, payload) => runEmulatorAction(payload));
   ipcMain.handle("codex:info", () => buildCodexInfo());
   ipcMain.handle("codex:connect", async () => {
     const info = await connectCodexBinary();

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -6,6 +6,7 @@ contextBridge.exposeInMainWorld("tasksApi", {
   complete: (id) => ipcRenderer.invoke("tasks:complete", id),
   remove: (id) => ipcRenderer.invoke("tasks:delete", id),
   runCodex: (payload) => ipcRenderer.invoke("tasks:run-codex", payload),
+  emulatorAction: (payload) => ipcRenderer.invoke("emulator:action", payload),
   getCodexInfo: () => ipcRenderer.invoke("codex:info"),
   connectCodex: () => ipcRenderer.invoke("codex:connect"),
   onTasksUpdated: (callback) =>

--- a/rust-backend/src/lib.rs
+++ b/rust-backend/src/lib.rs
@@ -115,6 +115,13 @@ impl TaskStore {
         })
     }
 
+    pub fn replace_all(&self, tasks: Vec<Task>) -> Result<Vec<Task>> {
+        self.with_state_write(|state| {
+            state.tasks = tasks;
+            Ok(Self::sort_tasks(state.tasks.clone()))
+        })
+    }
+
     pub fn mark_codex_queued(
         &self,
         id: &str,
@@ -424,6 +431,38 @@ mod tests {
         let updated = store.delete(&task_id).unwrap();
 
         assert!(updated.is_empty());
+    }
+
+    #[test]
+    fn replaces_all_tasks() {
+        let dir = tempdir().unwrap();
+        let store = TaskStore::new(dir.path().join("tasks.json"));
+
+        let tasks = store.add("Original task", None).unwrap();
+        let replacement = super::Task {
+            id: "replacement-1".to_owned(),
+            title: "Replacement task".to_owned(),
+            completed: true,
+            created_at: "2026-04-07T00:00:00Z".to_owned(),
+            import_type: "quick-add".to_owned(),
+            codex_status: "failed".to_owned(),
+            codex_last_run_at: None,
+            codex_last_output: None,
+            codex_last_error: Some("Mock error".to_owned()),
+            codex_log: Some("[message] replaced\n".to_owned()),
+            codex_workspace: None,
+            codex_workspace_source: None,
+            codex_runner_pid: None,
+        };
+
+        assert_eq!(tasks.len(), 1);
+
+        let replaced = store.replace_all(vec![replacement]).unwrap();
+
+        assert_eq!(replaced.len(), 1);
+        assert_eq!(replaced[0].title, "Replacement task");
+        assert!(replaced[0].completed);
+        assert_eq!(replaced[0].codex_status, "failed");
     }
 
     #[test]

--- a/rust-backend/src/main.rs
+++ b/rust-backend/src/main.rs
@@ -25,6 +25,8 @@ enum Command {
     Complete { id: String },
     #[serde(rename = "delete")]
     Delete { id: String },
+    #[serde(rename = "replace_all")]
+    ReplaceAll { tasks: Vec<Task> },
     #[serde(rename = "codex_mark_queued")]
     CodexMarkQueued {
         id: String,
@@ -89,6 +91,7 @@ fn main() -> Result<()> {
                     }
                     Command::Complete { id } => store.complete(&id),
                     Command::Delete { id } => store.delete(&id),
+                    Command::ReplaceAll { tasks } => store.replace_all(tasks),
                     Command::CodexMarkQueued {
                         id,
                         workspace,

--- a/scripts/me-emulator-lib.js
+++ b/scripts/me-emulator-lib.js
@@ -3,6 +3,8 @@ const os = require("node:os");
 const path = require("node:path");
 const crypto = require("node:crypto");
 
+const TOOLBOX_SHORTCUTS = ["open", "done", "queued", "running", "succeeded", "failed"];
+
 function npmCommand() {
   return process.platform === "win32" ? "npm.cmd" : "npm";
 }
@@ -197,6 +199,85 @@ function buildTask({
   };
 }
 
+function shortcutDefaults(shortcut) {
+  switch (shortcut) {
+    case "open":
+      return {
+        title: "Emulator open task",
+        completed: false,
+        codexStatus: "idle",
+        lastOutput: null,
+        lastError: null,
+        log: null,
+      };
+    case "done":
+      return {
+        title: "Emulator completed task",
+        completed: true,
+        codexStatus: "idle",
+        lastOutput: null,
+        lastError: null,
+        log: null,
+      };
+    case "queued":
+      return {
+        title: "Emulator queued task",
+        completed: false,
+        codexStatus: "queued",
+        lastOutput: null,
+        lastError: null,
+        log: "[message] Waiting in emulator queue\n",
+      };
+    case "running":
+      return {
+        title: "Emulator running task",
+        completed: false,
+        codexStatus: "running",
+        lastOutput: null,
+        lastError: null,
+        log: "[message] Emulator running step 1\n[message] Emulator running step 2\n",
+      };
+    case "succeeded":
+      return {
+        title: "Emulator succeeded task",
+        completed: false,
+        codexStatus: "succeeded",
+        lastOutput: "Emulator success output.",
+        lastError: null,
+        log: "[message] Emulator finished successfully\n",
+      };
+    case "failed":
+      return {
+        title: "Emulator failed task",
+        completed: false,
+        codexStatus: "failed",
+        lastOutput: null,
+        lastError: "Emulator failure output.",
+        log: "[message] Emulator failed on purpose\n",
+      };
+    default:
+      throw new Error(`Unknown emulator shortcut: ${shortcut}`);
+  }
+}
+
+function buildShortcutTask({ shortcut, title, runnerPid = null, createdAt = isoDateWithOffset(0) }) {
+  const preset = shortcutDefaults(shortcut);
+
+  return {
+    ...buildTask({
+      title: title?.trim() || preset.title,
+      completed: preset.completed,
+      createdAt,
+      codexStatus: preset.codexStatus,
+      lastOutput: preset.lastOutput,
+      lastError: preset.lastError,
+      log: preset.log,
+    }),
+    codex_runner_pid:
+      preset.codexStatus === "queued" || preset.codexStatus === "running" ? runnerPid : null,
+  };
+}
+
 function buildSeedTasks(seed = "demo") {
   switch (seed) {
     case "empty":
@@ -270,6 +351,9 @@ function parseEmulatorArgs(argv) {
 
 async function prepareEmulator({ profile = "slow", seed = "demo" } = {}) {
   const sandbox = await prepareSandbox("me-emulator-");
+  sandbox.env.ME_EMULATOR = "1";
+  sandbox.env.ME_EMULATOR_PROFILE = profile;
+  sandbox.env.ME_EMULATOR_SEED = seed;
 
   if (profile === "missing") {
     sandbox.profileLabel = "missing";
@@ -294,7 +378,9 @@ async function prepareEmulator({ profile = "slow", seed = "demo" } = {}) {
 }
 
 module.exports = {
+  TOOLBOX_SHORTCUTS,
   buildSeedTasks,
+  buildShortcutTask,
   createFakeCodexBinary,
   ensureDirectory,
   npmCommand,

--- a/src/index.html
+++ b/src/index.html
@@ -81,6 +81,45 @@
           <ul id="task-list" class="task-list"></ul>
         </section>
       </main>
+
+      <aside id="emulator-toolbox" class="toolbox-panel" hidden>
+        <div class="toolbox-header">
+          <div>
+            <h2>Toolbox</h2>
+            <p id="toolbox-meta" class="toolbox-meta"></p>
+          </div>
+        </div>
+
+        <label class="toolbox-input-shell" for="toolbox-text">
+          <span>Title</span>
+          <input
+            id="toolbox-text"
+            name="toolbox-text"
+            type="text"
+            maxlength="160"
+            placeholder="Emulator task"
+            autocomplete="off"
+          />
+        </label>
+
+        <div class="toolbox-grid">
+          <button class="toolbox-button" type="button" data-action="add-open">Open</button>
+          <button class="toolbox-button" type="button" data-action="add-done">Done</button>
+          <button class="toolbox-button" type="button" data-action="add-queued">Queued</button>
+          <button class="toolbox-button" type="button" data-action="add-running">Running</button>
+          <button class="toolbox-button" type="button" data-action="add-succeeded">
+            Succeeded
+          </button>
+          <button class="toolbox-button" type="button" data-action="add-failed">Failed</button>
+        </div>
+
+        <div class="toolbox-grid toolbox-grid-secondary">
+          <button class="toolbox-button" type="button" data-action="seed-demo">Seed Demo</button>
+          <button class="toolbox-button is-danger" type="button" data-action="clear-all">
+            Clear
+          </button>
+        </div>
+      </aside>
     </div>
 
     <template id="task-template">

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,3 +1,4 @@
+const shell = document.querySelector(".shell");
 const form = document.getElementById("task-form");
 const textInput = document.getElementById("task-text");
 const codexChip = document.getElementById("codex-chip");
@@ -11,6 +12,10 @@ const taskList = document.getElementById("task-list");
 const taskTemplate = document.getElementById("task-template");
 const emptyTemplate = document.getElementById("empty-template");
 const formError = document.getElementById("form-error");
+const emulatorToolbox = document.getElementById("emulator-toolbox");
+const toolboxMeta = document.getElementById("toolbox-meta");
+const toolboxText = document.getElementById("toolbox-text");
+const toolboxButtons = Array.from(document.querySelectorAll(".toolbox-button"));
 
 const CODEX_STATUS = {
   idle: "Codex Idle",
@@ -27,6 +32,11 @@ let codexInfo = {
   available: false,
   command: null,
   defaultWorkspace: "",
+  emulator: {
+    enabled: false,
+    profile: null,
+    seed: null,
+  },
 };
 
 function setBusy(nextBusy) {
@@ -35,8 +45,13 @@ function setBusy(nextBusy) {
   connectCodexButton.disabled = nextBusy;
   refreshButton.disabled = nextBusy;
   textInput.disabled = nextBusy;
+  toolboxText.disabled = nextBusy;
 
   for (const button of taskList.querySelectorAll("button")) {
+    button.disabled = nextBusy;
+  }
+
+  for (const button of toolboxButtons) {
     button.disabled = nextBusy;
   }
 }
@@ -178,6 +193,32 @@ function renderCodexInfo() {
     : "Connect Codex";
 }
 
+function renderEmulatorToolbox() {
+  const emulator = codexInfo.emulator || {};
+  const enabled = Boolean(emulator.enabled);
+
+  emulatorToolbox.hidden = !enabled;
+  shell.dataset.mode = enabled ? "emulator" : "default";
+
+  if (!enabled) {
+    toolboxMeta.textContent = "";
+    toolboxText.value = "";
+    return;
+  }
+
+  const metaParts = [];
+
+  if (emulator.profile) {
+    metaParts.push(`Profile ${emulator.profile}`);
+  }
+
+  if (emulator.seed) {
+    metaParts.push(`Seed ${emulator.seed}`);
+  }
+
+  toolboxMeta.textContent = metaParts.join(" · ");
+}
+
 function renderStats() {
   const completed = tasks.filter((task) => task.completed).length;
 
@@ -282,6 +323,7 @@ async function loadCodexInfo() {
   codexInfo = await window.tasksApi.getCodexInfo();
 
   renderCodexInfo();
+  renderEmulatorToolbox();
   renderList();
 }
 
@@ -293,6 +335,22 @@ async function connectCodex() {
     }
 
     renderCodexInfo();
+    renderEmulatorToolbox();
+    renderList();
+  });
+}
+
+async function runEmulatorAction(action) {
+  await withRequest(async () => {
+    tasks = await window.tasksApi.emulatorAction({
+      action,
+      title: toolboxText.value,
+    });
+
+    if (action.startsWith("add-")) {
+      toolboxText.select();
+    }
+
     renderList();
   });
 }
@@ -329,6 +387,19 @@ form.addEventListener("submit", async (event) => {
 
 refreshButton.addEventListener("click", refreshTasks);
 connectCodexButton.addEventListener("click", connectCodex);
+
+for (const button of toolboxButtons) {
+  button.addEventListener("click", () => runEmulatorAction(button.dataset.action));
+}
+
+toolboxText.addEventListener("keydown", (event) => {
+  if (event.key !== "Enter") {
+    return;
+  }
+
+  event.preventDefault();
+  void runEmulatorAction("add-open");
+});
 
 window.tasksApi.onTasksUpdated((nextTasks) => {
   tasks = nextTasks;

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,8 +41,13 @@ input {
   padding: 18px;
 }
 
+.shell[data-mode="emulator"] {
+  grid-template-columns: minmax(240px, 300px) minmax(0, 1fr) minmax(240px, 290px);
+}
+
 .hero-panel,
-.workspace-panel > section {
+.workspace-panel > section,
+.toolbox-panel {
   border: 1px solid var(--line);
   border-radius: 28px;
   background: var(--panel);
@@ -58,11 +63,27 @@ input {
   padding: 24px;
 }
 
+.toolbox-panel {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  min-height: 0;
+  padding: 20px;
+  overflow: auto;
+}
+
 .hero-panel h1,
 .workspace-panel h2 {
   margin: 0;
   font-family: var(--font-display);
   letter-spacing: -0.03em;
+}
+
+.toolbox-panel h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  letter-spacing: -0.03em;
+  font-size: 1.2rem;
 }
 
 .hero-panel h1 {
@@ -73,6 +94,18 @@ input {
 .stats-grid {
   display: grid;
   gap: 10px;
+}
+
+.toolbox-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.toolbox-meta {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 0.88rem;
 }
 
 .stat-card {
@@ -125,9 +158,19 @@ input {
   gap: 10px;
 }
 
+.toolbox-input-shell {
+  display: grid;
+  gap: 8px;
+}
+
 .input-shell span {
   color: var(--muted);
   font-size: 0.94rem;
+}
+
+.toolbox-input-shell span {
+  color: var(--muted);
+  font-size: 0.86rem;
 }
 
 .input-shell input {
@@ -141,8 +184,24 @@ input {
   transition: border-color 180ms ease, transform 180ms ease;
 }
 
+.toolbox-input-shell input {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.55);
+  color: var(--text);
+  outline: none;
+  transition: border-color 180ms ease, transform 180ms ease;
+}
+
 .input-shell input:focus {
   border-color: rgba(110, 231, 183, 0.65);
+  transform: translateY(-1px);
+}
+
+.toolbox-input-shell input:focus {
+  border-color: rgba(125, 211, 252, 0.58);
   transform: translateY(-1px);
 }
 
@@ -175,6 +234,27 @@ button:disabled {
   color: var(--text);
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.toolbox-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.toolbox-button {
+  padding: 12px 14px;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.toolbox-button:hover:not(:disabled) {
+  background: rgba(125, 211, 252, 0.14);
+}
+
+.toolbox-button.is-danger:hover:not(:disabled) {
+  background: rgba(249, 115, 115, 0.18);
 }
 
 .delete-button:hover:not(:disabled) {
@@ -537,7 +617,8 @@ button:disabled {
 
   .hero-panel,
   .composer-card,
-  .list-card {
+  .list-card,
+  .toolbox-panel {
     padding: 18px;
     border-radius: 22px;
   }

--- a/test/me-emulator-lib.test.js
+++ b/test/me-emulator-lib.test.js
@@ -4,7 +4,9 @@ const fs = require("node:fs/promises");
 const path = require("node:path");
 
 const {
+  TOOLBOX_SHORTCUTS,
   buildSeedTasks,
+  buildShortcutTask,
   parseEmulatorArgs,
   prepareCodexScenario,
   prepareEmulator,
@@ -36,6 +38,30 @@ test("buildSeedTasks returns demo fixtures", () => {
   assert.equal(tasks[0].codex_status, "idle");
   assert.equal(tasks[1].codex_status, "succeeded");
   assert.equal(tasks[2].codex_status, "failed");
+});
+
+test("buildShortcutTask creates running task with runner pid", () => {
+  const task = buildShortcutTask({
+    shortcut: "running",
+    title: "Shortcut task",
+    runnerPid: 999,
+  });
+
+  assert.equal(task.title, "Shortcut task");
+  assert.equal(task.codex_status, "running");
+  assert.equal(task.codex_runner_pid, 999);
+  assert.match(task.codex_log, /running step/i);
+});
+
+test("toolbox shortcut list is stable", () => {
+  assert.deepEqual(TOOLBOX_SHORTCUTS, [
+    "open",
+    "done",
+    "queued",
+    "running",
+    "succeeded",
+    "failed",
+  ]);
 });
 
 test("prepareCodexScenario isolates home and data paths", async () => {


### PR DESCRIPTION
## Summary
- add an emulator-only toolbox sidebar for fast task state setup
- support shortcut task creation and seed/reset actions through IPC
- expose emulator metadata in codex info and document the workflow

## Verification
- npm run test:backend
- npm run test:scenarios
- node --check electron/main.js
- node --check electron/preload.js
- node --check electron/codex-env.js
- node --check src/renderer.js
- node --check scripts/me-emulator-lib.js
- npm run emulator -- --profile slow --seed demo

Closes #15